### PR TITLE
Updated model clean to use strain.strain_species instead of strain.species

### DIFF
--- a/fsdviz/common/models.py
+++ b/fsdviz/common/models.py
@@ -506,8 +506,8 @@ class StrainRaw(BaseModel):
     def full_clean(self, *args, **kwargs):
         """make sure that the species and strain are consistent."""
 
-        if not hasattr(self, "species"):
-            self.species = self.strain.species.first()
+        if hasattr(self, "species") is False or self.species is None:
+            self.species = self.strain.strain_species
 
         super(StrainRaw, self).full_clean(*args, **kwargs)
 


### PR DESCRIPTION
This commit includes a single small change that should fix a bug in the StrainRaw model that was supposed to get the species from the associated strain (if it was not provided).  All tests continue to pass.